### PR TITLE
add remove card from bookmark page if it is not bookmarked

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -161,6 +161,7 @@ function renderFavorites(bookmarkedCards) {
             return allCard
           }
         })
+        cardElement.remove();
       })
     })
 }


### PR DESCRIPTION
Bookmark cards that are not bookmarked anymore are now removed from Favourites-Page.
Please review.